### PR TITLE
Stop player from re-enabling super form after completing a stage

### DIFF
--- a/SonicForGMS.gmx/objects/PlayableCharacter.object.gmx
+++ b/SonicForGMS.gmx/objects/PlayableCharacter.object.gmx
@@ -283,6 +283,8 @@ rev_audio_pitch = audio_sound_get_pitch(SpinRevSound);
 drowning_music = noone;
 
 chain_multiplier = 0;
+
+stage_end = false;
 </string>
           </argument>
         </arguments>

--- a/SonicForGMS.gmx/objects/SignPost.object.gmx
+++ b/SonicForGMS.gmx/objects/SignPost.object.gmx
@@ -73,6 +73,7 @@ case "wait":
             game_pc_lose_super(player.character);
             character = player.character_id;
             event_user(0);
+            player.character.stage_end = true;
             game_pc_play_sound(player.character, SignPostSound);
             with (ZoneTimeLimit) {
                 enabled = false;

--- a/SonicForGMS.gmx/objects/Sonic2Capsule.object.gmx
+++ b/SonicForGMS.gmx/objects/Sonic2Capsule.object.gmx
@@ -176,6 +176,7 @@ if (not opened) {
     }
     with (PlayableCharacter) {
         game_pc_lose_super(self);
+        stage_end = true;
     }
 }
 </string>

--- a/SonicForGMS.gmx/scripts/player_is_jumping.gml
+++ b/SonicForGMS.gmx/scripts/player_is_jumping.gml
@@ -64,7 +64,7 @@ case "step":
             } else {
                 if (superform) {
                     return game_pc_perform(self, player_is_super_sonic_flying);
-                } else if (owner.rings >= 50 and 
+                } else if (not stage_end and owner.rings >= 50 and 
                     not (recovery_time > 0 or invincibility_time > 0) and 
                     game_save_all_emeralds_found(game_save_current())) {
                     return game_pc_perform(self, player_is_transforming);
@@ -75,7 +75,7 @@ case "step":
             break;
 
         case Tails:
-            if (owner.rings >= 50 and 
+            if (not stage_end and owner.rings >= 50 and 
                 not (superform or recovery_time > 0 or invincibility_time > 0) and 
                 game_save_all_emeralds_found(game_save_current())) {
                 return game_pc_perform(self, player_is_transforming);
@@ -90,7 +90,7 @@ case "step":
             break;
 
         case Knuckles:
-            if (owner.rings >= 50 and 
+            if (not stage_end and owner.rings >= 50 and 
                 not (superform or recovery_time > 0 or invincibility_time > 0) and 
                 game_save_all_emeralds_found(game_save_current())) {
                 return game_pc_perform(self, player_is_transforming);


### PR DESCRIPTION
![Fix](https://user-images.githubusercontent.com/36262058/56450285-b70cb780-62d9-11e9-94eb-121d0b3b2d21.gif)

Currently, you are able to transform after hitting a signpost or capsule. This causes some odd behaviors with shaders. I think it would be best to disallow players from doing this. This is my approach to fixing this problem.