### PR TITLE
Freeze animated backgrounds when game is paused

### DIFF
--- a/SonicForGMS.gmx/objects/ParallaxSpriteLayer.object.gmx
+++ b/SonicForGMS.gmx/objects/ParallaxSpriteLayer.object.gmx
@@ -25,11 +25,17 @@
         <arguments>
           <argument>
             <kind>1</kind>
-            <string>/// Wrap texture
+            <string>/// Wrap texture (and animate)
 if (game_is_running()) {
     if (sprite_index != -1) {
         x = x mod (sprite_width + x_separation);
         y = y mod (sprite_height + y_separation);
+        image_speed = subspd;
+    }
+}
+else {
+    if (sprite_index != -1) {
+        image_speed = 0;
     }
 }
 </string>

--- a/SonicForGMS.gmx/scripts/game_parallax_add_sprite_layer.gml
+++ b/SonicForGMS.gmx/scripts/game_parallax_add_sprite_layer.gml
@@ -45,7 +45,7 @@ default:
 with (instance_create(0, 0, ParallaxSpriteLayer)) {
     sprite_index = sprite;
     image_index = subimg;
-    image_speed = subspd;
+    self.subspd = subspd;
     x_absolute = ox;
     y_absolute = oy;
     tile_horizontal = x_tiled;


### PR DESCRIPTION
![GIF](https://user-images.githubusercontent.com/36262058/57272632-81e6c000-7062-11e9-9306-26cc0dbd116f.gif)

These code changes will pause animations for all ParallaxSpriteLayer objects while the game is paused.